### PR TITLE
Fix test annotations

### DIFF
--- a/src/test/data/programs/assert_false.rs.json
+++ b/src/test/data/programs/assert_false.rs.json
@@ -1,17 +1,36 @@
 [
-    {
-        "message": "[Prusti: verification error] the asserted expression might not hold",
-        "range": {
-            "_end": {
-                "_character": 19,
-                "_line": 1
+    [
+        {
+            "message": "[Prusti: verification error] the asserted expression might not hold",
+            "range": {
+                "_end": {
+                    "_character": 18,
+                    "_line": 1
+                },
+                "_start": {
+                    "_character": 4,
+                    "_line": 1
+                }
             },
-            "_start": {
-                "_character": 4,
-                "_line": 1
-            }
-        },
-        "relatedInformation": [],
-        "severity": 0
-    }
+            "relatedInformation": [],
+            "severity": 0
+        }
+    ],
+    [
+        {
+            "message": "[Prusti: verification error] the asserted expression might not hold",
+            "range": {
+                "_end": {
+                    "_character": 19,
+                    "_line": 1
+                },
+                "_start": {
+                    "_character": 4,
+                    "_line": 1
+                }
+            },
+            "relatedInformation": [],
+            "severity": 0
+        }
+    ]
 ]


### PR DESCRIPTION
Apparently, the `LatestDev` and `LatestRelease` versions report diagnostics that differ by one meaningless character. In one case the span includes a trailing `;`, in the other not.