### PR TITLE
Fix tests and enable 'reportErrorsOnly' by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
                 },
                 "prusti-assistant.reportErrorsOnly": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Specifies if only error messages should be reported, hiding compiler's warnings."
                 },
                 "prusti-assistant.javaHome": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,7 @@ export function verifyOnOpen(): boolean {
 }
 
 export function reportErrorsOnly(): boolean {
-    return config().get("reportErrorsOnly", true);
+    return config().get("reportErrorsOnly", false);
 }
 
 // Avoid calling `findJavaHome()` each time.

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -38,5 +38,19 @@
             }
         ],
         "severity": 0
+    },
+    {
+        "message": "aborting due to previous error",
+        "range": {
+            "_end": {
+                "_character": 0,
+                "_line": 0
+            },
+            "_start": {
+                "_character": 0,
+                "_line": 0
+            }
+        },
+        "severity": 0
     }
 ]

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -1,7 +1,7 @@
 [
     {
         "filter": {
-            "os": "mac"
+            "prusti-assistant.buildChannel": "LatestRelease"
         },
         "diagnostics" : [
             {

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -1,6 +1,101 @@
 [
     {
         "filter": {
+            "os": "darwin",
+            "buildChannel": "LatestRelease"
+        },
+        "diagnostics": [
+            {
+                "message": "[Prusti: verification error] precondition might not hold.",
+                "range": {
+                    "_end": {
+                        "_character": 11,
+                        "_line": 8
+                    },
+                    "_start": {
+                        "_character": 4,
+                        "_line": 8
+                    }
+                },
+                "relatedInformation": [
+                    {
+                        "location": {
+                            "range": {
+                                "_end": {
+                                    "_character": 12,
+                                    "_line": 2
+                                },
+                                "_start": {
+                                    "_character": 11,
+                                    "_line": 2
+                                }
+                            },
+                            "uri": {
+                                "_formatted": null,
+                                "_fsPath": null,
+                                "authority": "",
+                                "fragment": "",
+                                "path": "crates/contracts/src/main.rs",
+                                "query": "",
+                                "scheme": "file"
+                            }
+                        },
+                        "message": "the failing assertion is here"
+                    }
+                ],
+                "severity": 0
+            }
+        ]
+    },
+    {
+        "filter": {
+            "os": "darwin"
+        },
+        "diagnostics": [
+            {
+                "message": "[Prusti: verification error] precondition might not hold.",
+                "range": {
+                    "_end": {
+                        "_character": 11,
+                        "_line": 8
+                    },
+                    "_start": {
+                        "_character": 4,
+                        "_line": 8
+                    }
+                },
+                "relatedInformation": [
+                    {
+                        "location": {
+                            "range": {
+                                "_end": {
+                                    "_character": 18,
+                                    "_line": 2
+                                },
+                                "_start": {
+                                    "_character": 11,
+                                    "_line": 2
+                                }
+                            },
+                            "uri": {
+                                "_formatted": null,
+                                "_fsPath": null,
+                                "authority": "",
+                                "fragment": "",
+                                "path": "crates/contracts/src/main.rs",
+                                "query": "",
+                                "scheme": "file"
+                            }
+                        },
+                        "message": "the failing assertion is here"
+                    }
+                ],
+                "severity": 0
+            }
+        ]
+    },
+    {
+        "filter": {
             "buildChannel": "LatestRelease"
         },
         "diagnostics" : [

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -1,56 +1,114 @@
 [
-    {
-        "message": "[Prusti: verification error] precondition might not hold.",
-        "range": {
-            "_end": {
-                "_character": 11,
-                "_line": 8
+    [
+        {
+            "message": "[Prusti: verification error] precondition might not hold.",
+            "range": {
+                "_end": {
+                    "_character": 11,
+                    "_line": 8
+                },
+                "_start": {
+                    "_character": 4,
+                    "_line": 8
+                }
             },
-            "_start": {
-                "_character": 4,
-                "_line": 8
-            }
-        },
-        "relatedInformation": [
-            {
-                "location": {
-                    "range": {
-                        "_end": {
-                            "_character": 12,
-                            "_line": 2
+            "relatedInformation": [
+                {
+                    "location": {
+                        "range": {
+                            "_end": {
+                                "_character": 12,
+                                "_line": 2
+                            },
+                            "_start": {
+                                "_character": 11,
+                                "_line": 2
+                            }
                         },
-                        "_start": {
-                            "_character": 11,
-                            "_line": 2
+                        "uri": {
+                            "_formatted": null,
+                            "_fsPath": null,
+                            "authority": "",
+                            "fragment": "",
+                            "path": "crates/contracts/src/main.rs",
+                            "query": "",
+                            "scheme": "file"
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
-                },
-                    "message": "the failing assertion is here"
-            }
-        ],
-        "severity": 0
-    },
-    {
-        "message": "aborting due to previous error",
-        "range": {
-            "_end": {
-                "_character": 0,
-                "_line": 0
-            },
-            "_start": {
-                "_character": 0,
-                "_line": 0
-            }
+                        "message": "the failing assertion is here"
+                }
+            ],
+            "severity": 0
         },
-        "severity": 0
-    }
+        {
+            "message": "aborting due to previous error",
+            "range": {
+                "_end": {
+                    "_character": 0,
+                    "_line": 0
+                },
+                "_start": {
+                    "_character": 0,
+                    "_line": 0
+                }
+            },
+            "severity": 0
+        }
+    ],
+    [
+        {
+            "message": "[Prusti: verification error] precondition might not hold.",
+            "range": {
+                "_end": {
+                    "_character": 11,
+                    "_line": 8
+                },
+                "_start": {
+                    "_character": 4,
+                    "_line": 8
+                }
+            },
+            "relatedInformation": [
+                {
+                    "location": {
+                        "range": {
+                            "_end": {
+                                "_character": 18,
+                                "_line": 2
+                            },
+                            "_start": {
+                                "_character": 11,
+                                "_line": 2
+                            }
+                        },
+                        "uri": {
+                            "_formatted": null,
+                            "_fsPath": null,
+                            "authority": "",
+                            "fragment": "",
+                            "path": "crates/contracts/src/main.rs",
+                            "query": "",
+                            "scheme": "file"
+                        }
+                    },
+                        "message": "the failing assertion is here"
+                }
+            ],
+            "severity": 0
+        },
+        {
+            "message": "aborting due to previous error",
+            "range": {
+                "_end": {
+                    "_character": 0,
+                    "_line": 0
+                },
+                "_start": {
+                    "_character": 0,
+                    "_line": 0
+                }
+            },
+            "severity": 0
+        }
+    ]
 ]

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -16,7 +16,7 @@
                 "location": {
                     "range": {
                         "_end": {
-                            "_character": 18,
+                            "_character": 12,
                             "_line": 2
                         },
                         "_start": {

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -1,7 +1,7 @@
 [
     {
         "filter": {
-            "prusti-assistant.buildChannel": "LatestRelease"
+            "buildChannel": "LatestRelease"
         },
         "diagnostics" : [
             {

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -16,7 +16,7 @@
                 "location": {
                     "range": {
                         "_end": {
-                            "_character": 12,
+                            "_character": 18,
                             "_line": 2
                         },
                         "_start": {

--- a/src/test/data/crates/contracts/src/main.rs.json
+++ b/src/test/data/crates/contracts/src/main.rs.json
@@ -1,114 +1,121 @@
 [
-    [
-        {
-            "message": "[Prusti: verification error] precondition might not hold.",
-            "range": {
-                "_end": {
-                    "_character": 11,
-                    "_line": 8
+    {
+        "filter": {
+            "os": "mac"
+        },
+        "diagnostics" : [
+            {
+                "message": "[Prusti: verification error] precondition might not hold.",
+                "range": {
+                    "_end": {
+                        "_character": 11,
+                        "_line": 8
+                    },
+                    "_start": {
+                        "_character": 4,
+                        "_line": 8
+                    }
                 },
-                "_start": {
-                    "_character": 4,
-                    "_line": 8
-                }
-            },
-            "relatedInformation": [
-                {
-                    "location": {
-                        "range": {
-                            "_end": {
-                                "_character": 12,
-                                "_line": 2
+                "relatedInformation": [
+                    {
+                        "location": {
+                            "range": {
+                                "_end": {
+                                    "_character": 12,
+                                    "_line": 2
+                                },
+                                "_start": {
+                                    "_character": 11,
+                                    "_line": 2
+                                }
                             },
-                            "_start": {
-                                "_character": 11,
-                                "_line": 2
+                            "uri": {
+                                "_formatted": null,
+                                "_fsPath": null,
+                                "authority": "",
+                                "fragment": "",
+                                "path": "crates/contracts/src/main.rs",
+                                "query": "",
+                                "scheme": "file"
                             }
                         },
-                        "uri": {
-                            "_formatted": null,
-                            "_fsPath": null,
-                            "authority": "",
-                            "fragment": "",
-                            "path": "crates/contracts/src/main.rs",
-                            "query": "",
-                            "scheme": "file"
-                        }
+                            "message": "the failing assertion is here"
+                    }
+                ],
+                "severity": 0
+            },
+            {
+                "message": "aborting due to previous error",
+                "range": {
+                    "_end": {
+                        "_character": 0,
+                        "_line": 0
                     },
-                        "message": "the failing assertion is here"
-                }
-            ],
-            "severity": 0
-        },
-        {
-            "message": "aborting due to previous error",
-            "range": {
-                "_end": {
-                    "_character": 0,
-                    "_line": 0
+                    "_start": {
+                        "_character": 0,
+                        "_line": 0
+                    }
                 },
-                "_start": {
-                    "_character": 0,
-                    "_line": 0
-                }
-            },
-            "severity": 0
-        }
-    ],
-    [
-        {
-            "message": "[Prusti: verification error] precondition might not hold.",
-            "range": {
-                "_end": {
-                    "_character": 11,
-                    "_line": 8
+                "severity": 0
+            }
+        ]
+    },
+    {
+        "diagnostics": [
+            {
+                "message": "[Prusti: verification error] precondition might not hold.",
+                "range": {
+                    "_end": {
+                        "_character": 11,
+                        "_line": 8
+                    },
+                    "_start": {
+                        "_character": 4,
+                        "_line": 8
+                    }
                 },
-                "_start": {
-                    "_character": 4,
-                    "_line": 8
-                }
-            },
-            "relatedInformation": [
-                {
-                    "location": {
-                        "range": {
-                            "_end": {
-                                "_character": 18,
-                                "_line": 2
+                "relatedInformation": [
+                    {
+                        "location": {
+                            "range": {
+                                "_end": {
+                                    "_character": 18,
+                                    "_line": 2
+                                },
+                                "_start": {
+                                    "_character": 11,
+                                    "_line": 2
+                                }
                             },
-                            "_start": {
-                                "_character": 11,
-                                "_line": 2
+                            "uri": {
+                                "_formatted": null,
+                                "_fsPath": null,
+                                "authority": "",
+                                "fragment": "",
+                                "path": "crates/contracts/src/main.rs",
+                                "query": "",
+                                "scheme": "file"
                             }
                         },
-                        "uri": {
-                            "_formatted": null,
-                            "_fsPath": null,
-                            "authority": "",
-                            "fragment": "",
-                            "path": "crates/contracts/src/main.rs",
-                            "query": "",
-                            "scheme": "file"
-                        }
-                    },
-                        "message": "the failing assertion is here"
-                }
-            ],
-            "severity": 0
-        },
-        {
-            "message": "aborting due to previous error",
-            "range": {
-                "_end": {
-                    "_character": 0,
-                    "_line": 0
-                },
-                "_start": {
-                    "_character": 0,
-                    "_line": 0
-                }
+                            "message": "the failing assertion is here"
+                    }
+                ],
+                "severity": 0
             },
-            "severity": 0
-        }
-    ]
+            {
+                "message": "aborting due to previous error",
+                "range": {
+                    "_end": {
+                        "_character": 0,
+                        "_line": 0
+                    },
+                    "_start": {
+                        "_character": 0,
+                        "_line": 0
+                    }
+                },
+                "severity": 0
+            }
+        ]
+    }
 ]

--- a/src/test/data/programs/assert_false.rs
+++ b/src/test/data/programs/assert_false.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 fn main() {
     assert!(false);
 }

--- a/src/test/data/programs/assert_false.rs.json
+++ b/src/test/data/programs/assert_false.rs.json
@@ -1,64 +1,31 @@
 [
-    [
-        {
-            "message": "[Prusti: verification error] the asserted expression might not hold",
-            "range": {
-                "_end": {
-                    "_character": 18,
-                    "_line": 1
-                },
-                "_start": {
-                    "_character": 4,
-                    "_line": 1
-                }
+    {
+        "message": "[Prusti: verification error] the asserted expression might not hold",
+        "range": {
+            "_end": {
+                "_character": 18,
+                "_line": 1
             },
-            "relatedInformation": [],
-            "severity": 0
+            "_start": {
+                "_character": 4,
+                "_line": 1
+            }
         },
-        {
-            "message": "aborting due to previous error",
-            "range": {
-                "_end": {
-                    "_character": 0,
-                    "_line": 0
-                },
-                "_start": {
-                    "_character": 0,
-                    "_line": 0
-                }
+        "relatedInformation": [],
+        "severity": 0
+    },
+    {
+        "message": "aborting due to previous error",
+        "range": {
+            "_end": {
+                "_character": 0,
+                "_line": 0
             },
-            "severity": 0
-        }
-    ],
-    [
-        {
-            "message": "[Prusti: verification error] the asserted expression might not hold",
-            "range": {
-                "_end": {
-                    "_character": 19,
-                    "_line": 1
-                },
-                "_start": {
-                    "_character": 4,
-                    "_line": 1
-                }
-            },
-            "relatedInformation": [],
-            "severity": 0
+            "_start": {
+                "_character": 0,
+                "_line": 0
+            }
         },
-        {
-            "message": "aborting due to previous error",
-            "range": {
-                "_end": {
-                    "_character": 0,
-                    "_line": 0
-                },
-                "_start": {
-                    "_character": 0,
-                    "_line": 0
-                }
-            },
-            "severity": 0
-        }
-    ]
+        "severity": 0
+    }
 ]

--- a/src/test/data/programs/assert_false.rs.json
+++ b/src/test/data/programs/assert_false.rs.json
@@ -4,11 +4,11 @@
         "range": {
             "_end": {
                 "_character": 18,
-                "_line": 1
+                "_line": 2
             },
             "_start": {
                 "_character": 4,
-                "_line": 1
+                "_line": 2
             }
         },
         "relatedInformation": [],

--- a/src/test/data/programs/assert_false.rs.json
+++ b/src/test/data/programs/assert_false.rs.json
@@ -14,6 +14,20 @@
             },
             "relatedInformation": [],
             "severity": 0
+        },
+        {
+            "message": "aborting due to previous error",
+            "range": {
+                "_end": {
+                    "_character": 0,
+                    "_line": 0
+                },
+                "_start": {
+                    "_character": 0,
+                    "_line": 0
+                }
+            },
+            "severity": 0
         }
     ],
     [
@@ -30,6 +44,20 @@
                 }
             },
             "relatedInformation": [],
+            "severity": 0
+        },
+        {
+            "message": "aborting due to previous error",
+            "range": {
+                "_end": {
+                    "_character": 0,
+                    "_line": 0
+                },
+                "_start": {
+                    "_character": 0,
+                    "_line": 0
+                }
+            },
             "severity": 0
         }
     ]

--- a/src/test/data/programs/assert_true.rs
+++ b/src/test/data/programs/assert_true.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 fn main() {
     assert!(true);
 }

--- a/src/test/data/programs/failing_post.rs
+++ b/src/test/data/programs/failing_post.rs
@@ -5,7 +5,10 @@ fn something_true() -> bool {
     true
 }
 
+#[allow(dead_code)]
+#[allow(unused_variables)]
 #[ensures(something_true() && false)]
 fn client(a: u32) {}
 
+#[allow(dead_code)]
 fn main() {}

--- a/src/test/data/programs/failing_post.rs.json
+++ b/src/test/data/programs/failing_post.rs.json
@@ -4,11 +4,11 @@
         "range": {
             "_end": {
                 "_character": 35,
-                "_line": 7
+                "_line": 9
             },
             "_start": {
                 "_character": 10,
-                "_line": 7
+                "_line": 9
             }
         },
         "relatedInformation": [
@@ -17,11 +17,11 @@
                     "range": {
                         "_end": {
                             "_character": 20,
-                            "_line": 8
+                            "_line": 10
                         },
                         "_start": {
                             "_character": 0,
-                            "_line": 8
+                            "_line": 10
                         }
                     },
                     "uri": {
@@ -37,6 +37,20 @@
                 "message": "the error originates here"
             }
         ],
+        "severity": 0
+    },
+    {
+        "message": "aborting due to previous error",
+        "range": {
+            "_end": {
+                "_character": 0,
+                "_line": 0
+            },
+            "_start": {
+                "_character": 0,
+                "_line": 0
+            }
+        },
         "severity": 0
     }
 ]

--- a/src/test/data/programs/lib_assert_true.rs
+++ b/src/test/data/programs/lib_assert_true.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 fn lib() {
     assert!(true);
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -82,7 +82,6 @@ describe("Extension", () => {
             ];
             const expected = JSON.parse(extectedData) as Diagnostics | MultiDiagnostics;
             let expectedMultiDiagnostics: MultiDiagnostics;
-            console.log("expected", expected);
             if (!expected.length || !("diagnostics" in expected[0])) {
                 expectedMultiDiagnostics = [
                     { "diagnostics": expected as Diagnostics }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4,8 +4,10 @@ import * as path from "path";
 import * as glob from "glob";
 import { expect } from "chai";
 import * as fs from "fs-extra";
+import * as config from "../config";
 import * as state from "../state";
 import * as extension from "../extension"
+import * as os from 'os';
 
 const PROJECT_ROOT = path.join(__dirname, "..", "..");
 const DATA_ROOT = path.join(PROJECT_ROOT, "src", "test", "data");
@@ -72,25 +74,72 @@ describe("Extension", () => {
             await vscode.commands.executeCommand("prusti-assistant.verify");
             const diagnostics = vscode.languages.getDiagnostics(document.uri);
             const extectedData = await fs.readFile(programPath + ".json", "utf-8");
-            type Diagnostics = [{relatedInformation: [ { location: { uri: { path: string } } }]}];
-            const exprected = JSON.parse(extectedData) as Diagnostics | [Diagnostics];
-            function patchUri(toPatch: Diagnostics) {
-                toPatch.forEach(d => {
+            type Diagnostics = [
+                { relatedInformation: [{ location: { uri: { path: string } } }] }
+            ];
+            type MultiDiagnostics = [
+                { filter?: [string: string], diagnostics: Diagnostics }
+            ];
+            const expected = JSON.parse(extectedData) as Diagnostics | MultiDiagnostics;
+            let expectedMultiDiagnostics: MultiDiagnostics;
+            console.log("expected", expected);
+            if (!expected.length || !("diagnostics" in expected[0])) {
+                expectedMultiDiagnostics = [
+                    { "diagnostics": expected as Diagnostics }
+                ];
+            } else {
+                expectedMultiDiagnostics = expected as MultiDiagnostics;
+            }
+            // Patch URI
+            expectedMultiDiagnostics.forEach(alternative => {
+                alternative.diagnostics.forEach(d => {
                     (d.relatedInformation || []).forEach(r => {
-                        r.location.uri = vscode.Uri.file(path.join(workspacePath(), r.location.uri.path));
+                        r.location.uri = vscode.Uri.file(
+                            path.join(workspacePath(), r.location.uri.path)
+                        );
                     })
                 });
+            });
+            // Different build-channel or OS migh report slightly different diagnostics.
+            let expectedDiagnostics = expectedMultiDiagnostics.find((alternative, index) => {
+                if (!alternative.filter) {
+                    console.log(
+                        `Find expected diagnostics: using default ` +
+                        `alternative ${index}.`
+                    );
+                    return true;
+                }
+                for (const [key, value] of Object.entries(alternative.filter)) {
+                    let actualValue: string
+                    if (key == "os") {
+                        actualValue = os.platform();
+                    } else {
+                        actualValue = config.config().get(key, "");
+                    }
+                    if (value != actualValue) {
+                        console.log(
+                            `Find expected diagnostics: alternative ${index} ` +
+                            `requires '${key}' to be '${value}', but its ` +
+                            `value is '${actualValue}'.`
+                        );
+                        return false;
+                    }
+                }
+                console.log(
+                    `Find expected diagnostics: using alternative ${index}.`
+                );
+                return true
+            });
+            if (!expectedDiagnostics) {
+                console.log(
+                    "Find expected diagnostics: found no matching alternative."
+                );
+                expectedDiagnostics = {
+                    "diagnostics": [] as unknown as Diagnostics
+                };
             }
-            // The LatestDev and LatestRelease versions migh report slightly different diagnostics.
-            if (exprected && Array.isArray(exprected[0])) {
-                const exprectedAlternatives = exprected as [Diagnostics];
-                exprectedAlternatives.forEach(alternative => patchUri(alternative));
-                expect(exprectedAlternatives).to.deep.contain(diagnostics);
-            } else {
-                const exprectedDiagnostics = exprected as Diagnostics;
-                patchUri(exprectedDiagnostics);
-                expect(exprectedDiagnostics).to.deep.equal(diagnostics);
-            }
+            // Compare
+            expect(expectedDiagnostics.diagnostics).to.deep.equal(diagnostics);
         });
     });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -113,7 +113,7 @@ describe("Extension", () => {
                     if (key == "os") {
                         actualValue = os.platform();
                     } else {
-                        actualValue = config.config().get(key, "");
+                        actualValue = config.config().get(key, "undefined");
                     }
                     if (value != actualValue) {
                         console.log(


### PR DESCRIPTION
By default Prusti Assistant show forward Rustc warnings to the user