### PR TITLE
Fix tests by mapping vscode Diagnostics to our own type

### DIFF
--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -204,7 +204,7 @@ describe("Extension", () => {
                 };
             }
 
-            expect(expectedDiagnostics.diagnostics).to.deep.equal(plainDiagnostics);
+            expect(plainDiagnostics).to.deep.equal(expectedDiagnostics.diagnostics);
         });
     });
 

--- a/src/test/scenarios/latestDev/crates/latest_contracts/src/main.rs.json
+++ b/src/test/scenarios/latestDev/crates/latest_contracts/src/main.rs.json
@@ -2,61 +2,45 @@
     {
         "message": "[unused_variables] unused variable: `unused`.",
         "range": {
-            "_end": {
-                "_character": 22,
-                "_line": 3
+            "end": {
+                "character": 22,
+                "line": 3
             },
-            "_start": {
-                "_character": 16,
-                "_line": 3
+            "start": {
+                "character": 16,
+                "line": 3
             }
         },
         "relatedInformation": [
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 22,
-                            "_line": 3
+                        "end": {
+                            "character": 22,
+                            "line": 3
                         },
-                        "_start": {
-                            "_character": 16,
-                            "_line": 3
+                        "start": {
+                            "character": 16,
+                            "line": 3
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/latest_contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "crates/latest_contracts/src/main.rs"
                 },
                 "message": "`#[warn(unused_variables)]` on by default"
             },
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 22,
-                            "_line": 3
+                        "end": {
+                            "character": 22,
+                            "line": 3
                         },
-                        "_start": {
-                            "_character": 16,
-                            "_line": 3
+                        "start": {
+                            "character": 16,
+                            "line": 3
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/latest_contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "crates/latest_contracts/src/main.rs"
                 },
                 "message": "if this is intentional, prefix it with an underscore"
             }
@@ -66,37 +50,29 @@
     {
         "message": "[Prusti: verification error] precondition might not hold.",
         "range": {
-            "_end": {
-                "_character": 14,
-                "_line": 8
+            "end": {
+                "character": 14,
+                "line": 8
             },
-            "_start": {
-                "_character": 4,
-                "_line": 8
+            "start": {
+                "character": 4,
+                "line": 8
             }
         },
         "relatedInformation": [
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 18,
-                            "_line": 2
+                        "end": {
+                            "character": 18,
+                            "line": 2
                         },
-                        "_start": {
-                            "_character": 11,
-                            "_line": 2
+                        "start": {
+                            "character": 11,
+                            "line": 2
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/latest_contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "crates/latest_contracts/src/main.rs"
                 },
                 "message": "the failing assertion is here"
             }

--- a/src/test/scenarios/shared/crates/published_contracts/src/main.rs.json
+++ b/src/test/scenarios/shared/crates/published_contracts/src/main.rs.json
@@ -2,61 +2,45 @@
     {
         "message": "[unused_variables] unused variable: `unused`.",
         "range": {
-            "_end": {
-                "_character": 22,
-                "_line": 3
+            "end": {
+                "character": 22,
+                "line": 3
             },
-            "_start": {
-                "_character": 16,
-                "_line": 3
+            "start": {
+                "character": 16,
+                "line": 3
             }
         },
         "relatedInformation": [
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 22,
-                            "_line": 3
+                        "end": {
+                            "character": 22,
+                            "line": 3
                         },
-                        "_start": {
-                            "_character": 16,
-                            "_line": 3
+                        "start": {
+                            "character": 16,
+                            "line": 3
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/published_contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "crates/published_contracts/src/main.rs"
                 },
                 "message": "`#[warn(unused_variables)]` on by default"
             },
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 22,
-                            "_line": 3
+                        "end": {
+                            "character": 22,
+                            "line": 3
                         },
-                        "_start": {
-                            "_character": 16,
-                            "_line": 3
+                        "start": {
+                            "character": 16,
+                            "line": 3
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/published_contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "crates/published_contracts/src/main.rs"
                 },
                 "message": "if this is intentional, prefix it with an underscore"
             }
@@ -66,37 +50,29 @@
     {
         "message": "[Prusti: verification error] precondition might not hold.",
         "range": {
-            "_end": {
-                "_character": 14,
-                "_line": 8
+            "end": {
+                "character": 14,
+                "line": 8
             },
-            "_start": {
-                "_character": 4,
-                "_line": 8
+            "start": {
+                "character": 4,
+                "line": 8
             }
         },
         "relatedInformation": [
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 18,
-                            "_line": 2
+                        "end": {
+                            "character": 18,
+                            "line": 2
                         },
-                        "_start": {
-                            "_character": 11,
-                            "_line": 2
+                        "start": {
+                            "character": 11,
+                            "line": 2
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "crates/published_contracts/src/main.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "crates/published_contracts/src/main.rs"
                 },
                 "message": "the failing assertion is here"
             }

--- a/src/test/scenarios/shared/programs/assert_false.rs.json
+++ b/src/test/scenarios/shared/programs/assert_false.rs.json
@@ -2,13 +2,13 @@
     {
         "message": "[Prusti: verification error] the asserted expression might not hold",
         "range": {
-            "_end": {
-                "_character": 18,
-                "_line": 2
+            "end": {
+                "character": 18,
+                "line": 2
             },
-            "_start": {
-                "_character": 4,
-                "_line": 2
+            "start": {
+                "character": 4,
+                "line": 2
             }
         },
         "relatedInformation": [],

--- a/src/test/scenarios/shared/programs/failing_post.rs.json
+++ b/src/test/scenarios/shared/programs/failing_post.rs.json
@@ -2,37 +2,29 @@
     {
         "message": "[Prusti: verification error] postcondition might not hold.",
         "range": {
-            "_end": {
-                "_character": 35,
-                "_line": 9
+            "end": {
+                "character": 35,
+                "line": 9
             },
-            "_start": {
-                "_character": 10,
-                "_line": 9
+            "start": {
+                "character": 10,
+                "line": 9
             }
         },
         "relatedInformation": [
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 20,
-                            "_line": 10
+                        "end": {
+                            "character": 20,
+                            "line": 10
                         },
-                        "_start": {
-                            "_character": 0,
-                            "_line": 10
+                        "start": {
+                            "character": 0,
+                            "line": 10
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "programs/failing_post.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "programs/failing_post.rs"
                 },
                 "message": "the error originates here"
             }

--- a/src/test/scenarios/shared/programs/notes.rs.json
+++ b/src/test/scenarios/shared/programs/notes.rs.json
@@ -2,61 +2,45 @@
     {
         "message": "[unused_variables] unused variable: `unused`.",
         "range": {
-            "_end": {
-                "_character": 14,
-                "_line": 1
+            "end": {
+                "character": 14,
+                "line": 1
             },
-            "_start": {
-                "_character": 8,
-                "_line": 1
+            "start": {
+                "character": 8,
+                "line": 1
             }
         },
         "relatedInformation": [
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 14,
-                            "_line": 1
+                        "end": {
+                            "character": 14,
+                            "line": 1
                         },
-                        "_start": {
-                            "_character": 8,
-                            "_line": 1
+                        "start": {
+                            "character": 8,
+                            "line": 1
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "programs/notes.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "programs/notes.rs"
                 },
                 "message": "`#[warn(unused_variables)]` on by default"
             },
             {
                 "location": {
                     "range": {
-                        "_end": {
-                            "_character": 14,
-                            "_line": 1
+                        "end": {
+                            "character": 14,
+                            "line": 1
                         },
-                        "_start": {
-                            "_character": 8,
-                            "_line": 1
+                        "start": {
+                            "character": 8,
+                            "line": 1
                         }
                     },
-                    "uri": {
-                        "_formatted": null,
-                        "_fsPath": null,
-                        "authority": "",
-                        "fragment": "",
-                        "path": "programs/notes.rs",
-                        "query": "",
-                        "scheme": "file"
-                    }
+                    "uri": "programs/notes.rs"
                 },
                 "message": "if this is intentional, prefix it with an underscore"
             }


### PR DESCRIPTION
fixes #210 

Regarding your suggestion, the linter did not like the `any` types you suggested as return types, that's why I created new types.

Locally it still failed a testcase, however I also fail this one on the original master branch. Prusti seems to crash for that case.

Another remark: I noticed that when failing testcases the labeling of the differences (actual vs. expected) is reversed. If you want I can add a commit swapping them.